### PR TITLE
feature/streaming market data

### DIFF
--- a/customers.go
+++ b/customers.go
@@ -104,22 +104,3 @@ func (c *Client) GetMyAccount(accountNumber string) (Account, *http.Response, er
 
 	return customersRes.Account, resp, nil
 }
-
-// Returns the appropriate quote streamer endpoint, level and identification token.
-// for the current customer to receive market data.
-func (c *Client) GetQuoteStreamerTokens() (QuoteStreamerTokenAuthResult, *http.Response, error) {
-	path := "/quote-streamer-tokens"
-
-	type customerResponse struct {
-		Streamer QuoteStreamerTokenAuthResult `json:"data"`
-	}
-
-	customersRes := new(customerResponse)
-
-	resp, err := c.request(http.MethodGet, path, nil, nil, customersRes)
-	if err != nil {
-		return QuoteStreamerTokenAuthResult{}, resp, err
-	}
-
-	return customersRes.Streamer, resp, nil
-}

--- a/customers_models.go
+++ b/customers_models.go
@@ -171,10 +171,3 @@ type EntityOfficer struct {
 	OwnerOfRecord        bool    `json:"owner-of-record"`
 	Address              Address `json:"address"`
 }
-
-type QuoteStreamerTokenAuthResult struct {
-	Token        string `json:"token"`
-	StreamerURL  string `json:"streamer-url"`
-	WebsocketURL string `json:"websocket-url"`
-	Level        string `json:"level"`
-}

--- a/customers_test.go
+++ b/customers_test.go
@@ -401,38 +401,6 @@ func TestGetMyAccountError(t *testing.T) {
 	require.NotNil(t, httpResp)
 }
 
-func TestGetQuoteStreamerTokens(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/quote-streamer-tokens", func(writer http.ResponseWriter, request *http.Request) {
-		fmt.Fprint(writer, quoteStreamerTokensResp)
-	})
-
-	resp, httpResp, err := client.GetQuoteStreamerTokens()
-	require.Nil(t, err)
-	require.NotNil(t, httpResp)
-
-	require.Equal(t, "example-token-here", resp.Token)
-	require.Equal(t, "tasty-live.dxfeed.com:7301", resp.StreamerURL)
-	require.Equal(t, "https://tasty-live-web.dxfeed.com/live", resp.WebsocketURL)
-	require.Equal(t, "live", resp.Level)
-}
-
-func TestGetQuoteStreamerTokensError(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/quote-streamer-tokens", func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(401)
-		fmt.Fprint(writer, tastyUnauthorizedError)
-	})
-
-	_, httpResp, err := client.GetQuoteStreamerTokens()
-	expectedUnauthorized(t, err)
-	require.NotNil(t, httpResp)
-}
-
 const getCustomerResp = `{
   "data": {
     "id": "me",
@@ -574,16 +542,6 @@ const getCustomerResp = `{
     }
   },
   "context": "/customers/me"
-}`
-
-const quoteStreamerTokensResp = `{
-  "data": {
-    "token": "example-token-here",
-    "streamer-url": "tasty-live.dxfeed.com:7301",
-    "websocket-url": "https://tasty-live-web.dxfeed.com/live",
-    "level": "live"
-  },
-  "context": "/quote-streamer-tokens"
 }`
 
 const getCustomerAccountResp = `{

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,22 @@
+package tasty
+
+import "net/http"
+
+// Returns the appropriate API quote streamer endpoint, level and identification token
+// for the current customer to receive market data.
+func (c *Client) GetQuoteStreamerTokens() (QuoteStreamerTokenAuthResult, *http.Response, error) {
+	path := "/api-quote-tokens"
+
+	type customerResponse struct {
+		Streamer QuoteStreamerTokenAuthResult `json:"data"`
+	}
+
+	customersRes := new(customerResponse)
+
+	resp, err := c.request(http.MethodGet, path, nil, nil, customersRes)
+	if err != nil {
+		return QuoteStreamerTokenAuthResult{}, resp, err
+	}
+
+	return customersRes.Streamer, resp, nil
+}

--- a/streaming_models.go
+++ b/streaming_models.go
@@ -1,0 +1,10 @@
+package tasty
+
+// Response from the API quote streamer request.
+type QuoteStreamerTokenAuthResult struct {
+	// API quote token unique to the customer identified by the session
+	// Quote streamer tokens are valid for 24 hours.
+	Token     string `json:"token"`
+	DXLinkURL string `json:"dxlink-url"`
+	Level     string `json:"level"`
+}

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -1,0 +1,49 @@
+package tasty //nolint:testpackage // testing private field
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetQuoteStreamerTokens(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api-quote-tokens", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer, quoteStreamerTokensResp)
+	})
+
+	resp, httpResp, err := client.GetQuoteStreamerTokens()
+	require.Nil(t, err)
+	require.NotNil(t, httpResp)
+
+	require.Equal(t, "example-token-here", resp.Token)
+	require.Equal(t, "wss://tasty-openapi-ws.dxfeed.com/realtime", resp.DXLinkURL)
+	require.Equal(t, "api", resp.Level)
+}
+
+func TestGetQuoteStreamerTokensError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api-quote-tokens", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(401)
+		fmt.Fprint(writer, tastyUnauthorizedError)
+	})
+
+	_, httpResp, err := client.GetQuoteStreamerTokens()
+	expectedUnauthorized(t, err)
+	require.NotNil(t, httpResp)
+}
+
+const quoteStreamerTokensResp = `{
+  "data": {
+    "token": "example-token-here",
+    "dxlink-url": "wss://tasty-openapi-ws.dxfeed.com/realtime",
+    "level": "api"
+  },
+  "context": "/api-quote-tokens"
+}`


### PR DESCRIPTION
Update to streaming market data endpoint.

## Tastytrade's Notification

We trust you are having a positive experience with the tastytrade Open API. We are reaching out to inform you that we are upgrading and provisioning dedicated streaming market data capacity for Open API consumers, which will require a code update to your application. We have updated the Streaming Market Data section of our documentation here: https://developer.tastytrade.com/streaming-market-data/ with relevant details about the new dxLink protocol and with the new endpoints.

For a short transitional period, the market data available on the Open API multiplexors will be limited to US-listed equities, SMALL exchange futures, and cryptocurrency. We are working diligently to add US-listed equity options, CFE and CME futures.
We are requiring customers to read the updated documentation and make the necessary updates to their applications to transition to these new multiplexors within the next 48 business hours. After 48 business hours, any accounts still using the old multiplexors will be moved to delayed quotes until they make the necessary updates. This will impact both your API and platform market data. We recognize the inconvenience of this change and temporary limited data offering, but in the long run this will present a better experience for Open API customers.

As soon as we have successfully onboarded the remaining instruments, we will be sending announcements to let you know. Thank you for your understanding and commitment to using the tastytrade Open API.

If you have any questions or concerns please reach out to our API Support team at [api.support@tastytrade.com](mailto:api.support@tastytrade.com).